### PR TITLE
[ci] Enable travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ cover-master
 .cache
 .test_results/
 rally-cli-output-files/
+.pytest_cache
 
 # Docs
 doc/source/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+matrix:
+  include:
+    # stylish checks
+    - python: 3.6
+      env:
+        JOB_NAME=pep8
+        TOXENV=pep8
+    # unittesting 2.7 - 3.6
+    - python: 2.7
+      env:
+        JOB_NAME=unittest
+        TOXENV=py27
+    - python: 3.5
+      env:
+        JOB_NAME=unittest
+        TOXENV=py35
+    - python: 3.6
+      env:
+        JOB_NAME=unittest
+        TOXENV=py36
+script:
+  - tox
+install:
+- pip install tox

--- a/tests/unit/test_none.py
+++ b/tests/unit/test_none.py
@@ -1,0 +1,25 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+The goal of this file is to add first unit test, so we can enable CI for new
+changes.
+"""
+
+from tests.unit import test
+
+
+class TestNone(test.TestCase):
+    def test_none(self):
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -4,31 +4,35 @@ skipsdist = True
 envlist = py35,py34,py27,pep8
 
 [testenv]
-extras = {env:RALLY_EXTRAS:}
 setenv = VIRTUAL_ENV={envdir}
-         HOME={homedir}
          LANG=en_US.UTF-8
          LANGUAGE=en_US:en
          LC_ALL=C
          PYTHONHASHSEED=0
          TOX_ENV_NAME={envname}
+         # see https://github.com/travis-ci/travis-ci/issues/7940
+         BOTO_CONFIG=/dev/null
 whitelist_externals = find
                       rm
                       make
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-install_command = pip install -c ./upper-constraints.txt -U {opts} {packages}
+install_command = pip install {packages}
 usedevelop = True
 commands =
   find . -type f -name "*.pyc" -delete
   python {toxinidir}/tests/ci/pytest_launcher.py tests/unit --posargs={posargs}
 distribute = false
-basepython = python2.7
+basepython = python3.6
 passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 
 [testenv:pep8]
 commands = flake8
 distribute = false
+
+
+[testenv:py27]
+basepython = python2.7
 
 
 [testenv:py34]
@@ -39,22 +43,19 @@ basepython = python3.4
 basepython = python3.5
 
 
+[testenv:py36]
+basepython = python3.6
+
+
 [testenv:venv]
 commands = {posargs}
+
 
 [testenv:cover]
 commands = {toxinidir}/tests/ci/cover.sh {posargs}
 
-[testenv:docs]
-changedir = doc/source
-commands =
-  rm -rf _build
-  make html
 
 [flake8]
 ignore = H703,H105
 show-source = true
 exclude=.venv,.git,.tox,dist,*lib/python*,*egg,tools,build,setup.py
-
-[hacking]
-local-check-factory = tests.hacking.checks.factory


### PR DESCRIPTION
* Add travis basic configuration which launchs pep8, py27 and py34
  checks via tox
* Add empty test to pass the unit check (if no tests are discovered,
  pytest assumes that something is wrong)
* Add pytest cache dir to gitignore