### PR TITLE
Implement rally scenarios for replication controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * [context plugin] namespaces - create number of namespaces (with
   non-default serviceAccounts optionally)
 * [scenario plugin] Kubernetes.create_and_delete_pod
+* [scenario plugin] Kubernetes.create_and_delete_replication_controller
+* [scenario plugin] Kubernetes.create_scale_and_delete_replication_controller
 
 ## [1.0.0] - 2018-06-26
 

--- a/samples/scenario/create-and-delete-replication-controller.json
+++ b/samples/scenario/create-and-delete-replication-controller.json
@@ -1,0 +1,48 @@
+{
+  "version": 2,
+  "title": "Create, read and delete replication controller with random name",
+  "subtasks": [
+    {
+      "title": "Run a single workload with create/read/delete replication controller",
+      "scenario": {
+        "Kubernetes.create_and_delete_replication_controller": {
+          "image": "kubernetes/pause",
+          "replicas": 2
+        }
+      },
+      "runner": {
+        "constant": {
+          "concurrency": 2,
+          "times": 10
+        }
+      },
+      "contexts": {
+        "namespaces": {
+          "count": 3,
+          "with_serviceaccount": true
+        }
+      }
+    },
+    {
+      "title": "Run create/read/delete replication controller with rps runner",
+      "scenario": {
+        "Kubernetes.create_and_delete_replication_controller": {
+          "image": "kubernetes/pause",
+          "replicas": 2
+        }
+      },
+      "runner": {
+        "rps": {
+          "rps": 2,
+          "times": 10
+        }
+      },
+      "contexts": {
+        "namespaces": {
+          "count": 3,
+          "with_serviceaccount": true
+        }
+      }
+    }
+  ]
+}

--- a/samples/scenario/create-and-delete-replication-controller.yaml
+++ b/samples/scenario/create-and-delete-replication-controller.yaml
@@ -1,0 +1,30 @@
+---
+version: 2
+title: Create, read and delete replication controller with random name
+subtasks:
+- title: Run a single workload with create/read/delete replication controller
+  scenario:
+    Kubernetes.create_and_delete_replication_controller:
+      image: kubernetes/pause
+      replicas: 2
+  runner:
+    constant:
+      concurrency: 2
+      times: 10
+  contexts:
+    namespaces:
+      count: 3
+      with_serviceaccount: true
+- title: Run create/read/delete replication controller with rps runner
+  scenario:
+    Kubernetes.create_and_delete_replication_controller:
+      image: kubernetes/pause
+      replicas: 2
+  runner:
+    rps:
+      rps: 2
+      times: 10
+  contexts:
+    namespaces:
+      count: 3
+      with_serviceaccount: true

--- a/samples/scenario/create-scale-and-delete-replication-controller.json
+++ b/samples/scenario/create-scale-and-delete-replication-controller.json
@@ -1,0 +1,50 @@
+{
+  "version": 2,
+  "title": "Create, scale and delete replication controller with random name",
+  "subtasks": [
+    {
+      "title": "Run a single workload with create/scale/delete replication controller",
+      "scenario": {
+        "Kubernetes.create_scale_and_delete_replication_controller": {
+          "image": "kubernetes/pause",
+          "replicas": 2,
+          "scale_replicas": 3
+        }
+      },
+      "runner": {
+        "constant": {
+          "concurrency": 2,
+          "times": 10
+        }
+      },
+      "contexts": {
+        "namespaces": {
+          "count": 3,
+          "with_serviceaccount": true
+        }
+      }
+    },
+    {
+      "title": "Run create/scale/delete replication controller with rps runner",
+      "scenario": {
+        "Kubernetes.create_scale_and_delete_replication_controller": {
+          "image": "kubernetes/pause",
+          "replicas": 2,
+          "scale_replicas": 3
+        }
+      },
+      "runner": {
+        "rps": {
+          "rps": 2,
+          "times": 10
+        }
+      },
+      "contexts": {
+        "namespaces": {
+          "count": 3,
+          "with_serviceaccount": true
+        }
+      }
+    }
+  ]
+}

--- a/samples/scenario/create-scale-and-delete-replication-controller.yaml
+++ b/samples/scenario/create-scale-and-delete-replication-controller.yaml
@@ -1,0 +1,32 @@
+---
+version: 2
+title: Create, scale and delete replication controller with random name
+subtasks:
+- title: Run a single workload with create/scale/delete replication controller
+  scenario:
+    Kubernetes.create_scale_and_delete_replication_controller:
+      image: kubernetes/pause
+      replicas: 2
+      scale_replicas: 3
+  runner:
+    constant:
+      concurrency: 2
+      times: 10
+  contexts:
+    namespaces:
+      count: 3
+      with_serviceaccount: true
+- title: Run create/scale/delete replication controller with rps runner
+  scenario:
+    Kubernetes.create_scale_and_delete_replication_controller:
+      image: kubernetes/pause
+      replicas: 2
+      scale_replicas: 3
+  runner:
+    rps:
+      rps: 2
+      times: 10
+  contexts:
+    namespaces:
+      count: 3
+      with_serviceaccount: true

--- a/tests/unit/tasks/scenarios/test_replication_controllers.py
+++ b/tests/unit/tasks/scenarios/test_replication_controllers.py
@@ -1,0 +1,209 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from kubernetes.client import rest
+
+from tests.unit import test
+from xrally_kubernetes.tasks.scenarios import replication_controllers
+
+
+class CreateAndDeleteReplicationControllerTestCase(test.TestCase):
+
+    def setUp(self):
+        super(CreateAndDeleteReplicationControllerTestCase, self).setUp()
+        self.scenario = replication_controllers.RCCreateAndDelete()
+        self.client = mock.MagicMock()
+        self.scenario.client = self.client
+        self.scenario.context = {
+            "iteration": 1,
+            "kubernetes": {
+                "namespaces": ["ns"],
+                "namespace_choice_method": "round_robin"
+            }
+        }
+
+    def test_create_and_delete_success(self):
+        self.client.create_rc.return_value = "test"
+
+        self.scenario.run("test/image", 2, command=["ls"])
+
+        self.client.create_rc.assert_called_once_with(
+            None,
+            namespace="ns",
+            image="test/image",
+            replicas=2,
+            command=["ls"],
+            status_wait=True
+        )
+        self.client.delete_rc.assert_called_once_with(
+            "test",
+            namespace="ns",
+            status_wait=True
+        )
+
+    def test_create_failed(self):
+        self.client.create_rc.side_effect = [
+            rest.ApiException(status=500, reason="Test")
+        ]
+
+        self.assertRaises(rest.ApiException, self.scenario.run,
+                          "test/image", 2)
+        self.client.create_rc.assert_called_once_with(
+            None,
+            namespace="ns",
+            image="test/image",
+            replicas=2,
+            command=None,
+            status_wait=True
+        )
+        self.assertEqual(0, self.client.delete_rc.call_count)
+
+    def test_delete_failed(self):
+        self.client.create_rc.return_value = "test"
+        self.client.delete_rc.side_effect = [
+            rest.ApiException(status=500, reason="Test")
+        ]
+
+        self.assertRaises(rest.ApiException, self.scenario.run,
+                          "test/image", 2)
+        self.client.create_rc.assert_called_once_with(
+            None,
+            command=None,
+            namespace="ns",
+            replicas=2,
+            image="test/image",
+            status_wait=True
+        )
+
+
+class CreateScaleAndDeleteReplicationControllerTestCase(test.TestCase):
+
+    def setUp(self):
+        super(CreateScaleAndDeleteReplicationControllerTestCase, self).setUp()
+        self.scenario = replication_controllers.CreateScaleAndDeleteRCPlugin()
+        self.client = mock.MagicMock()
+        self.scenario.client = self.client
+        self.scenario.context = {
+            "iteration": 1,
+            "kubernetes": {
+                "namespaces": ["ns"],
+                "namespace_choice_method": "round_robin"
+            }
+        }
+
+    def test_create_and_delete_success(self):
+        self.client.create_rc.return_value = "test"
+
+        self.scenario.run("test/image", 2, 3, command=["ls"])
+
+        self.client.create_rc.assert_called_once_with(
+            None,
+            namespace="ns",
+            image="test/image",
+            replicas=2,
+            command=["ls"],
+            status_wait=True
+        )
+        self.assertEqual(2, self.client.scale_rc.call_count)
+        self.client.delete_rc.assert_called_once_with(
+            "test",
+            namespace="ns",
+            status_wait=True
+        )
+
+    def test_create_failed(self):
+        self.client.create_rc.side_effect = [
+            rest.ApiException(status=500, reason="Test")
+        ]
+
+        self.assertRaises(rest.ApiException, self.scenario.run,
+                          "test/image", 2, 3)
+        self.client.create_rc.assert_called_once_with(
+            None,
+            namespace="ns",
+            image="test/image",
+            replicas=2,
+            command=None,
+            status_wait=True
+        )
+        self.assertEqual(0, self.client.scale_rc.call_count)
+        self.assertEqual(0, self.client.delete_rc.call_count)
+
+    def test_first_scale_failed(self):
+        self.client.create_rc.return_value = "test"
+        self.client.scale_rc.side_effect = [
+            rest.ApiException(status=500, reason="Test")
+        ]
+
+        self.assertRaises(rest.ApiException, self.scenario.run,
+                          "test/image", 2, 3)
+        self.client.create_rc.assert_called_once_with(
+            None,
+            namespace="ns",
+            image="test/image",
+            replicas=2,
+            command=None,
+            status_wait=True
+        )
+        self.client.scale_rc.assert_called_once_with(
+            "test",
+            namespace="ns",
+            replicas=3,
+            status_wait=True
+        )
+        self.assertEqual(0, self.client.delete_rc.call_count)
+
+    def test_second_scale_failed(self):
+        self.client.create_rc.return_value = "test"
+        self.client.scale_rc.side_effect = [
+            None, rest.ApiException(status=500, reason="Test")
+        ]
+
+        self.assertRaises(rest.ApiException, self.scenario.run,
+                          "test/image", 2, 3)
+        self.client.create_rc.assert_called_once_with(
+            None,
+            namespace="ns",
+            image="test/image",
+            replicas=2,
+            command=None,
+            status_wait=True
+        )
+        self.assertEqual(2, self.client.scale_rc.call_count)
+        self.assertEqual(dict(
+            namespace="ns",
+            replicas=2,
+            status_wait=True
+        ), self.client.scale_rc.call_args[1])
+        self.assertEqual(0, self.client.delete_rc.call_count)
+
+    def test_delete_failed(self):
+        self.client.create_rc.return_value = "test"
+        self.client.delete_rc.side_effect = [
+            rest.ApiException(status=500, reason="Test")
+        ]
+
+        self.assertRaises(rest.ApiException, self.scenario.run,
+                          "test/image", 2, 3)
+        self.client.create_rc.assert_called_once_with(
+            None,
+            command=None,
+            namespace="ns",
+            replicas=2,
+            image="test/image",
+            status_wait=True
+        )
+        self.assertEqual(2, self.client.scale_rc.call_count)

--- a/xrally_kubernetes/service.py
+++ b/xrally_kubernetes/service.py
@@ -63,6 +63,44 @@ def wait_for_status(name, status, read_method, resource_type=None, **kwargs):
                 timeout=(retries_total * sleep_time))
 
 
+def wait_for_ready_replicas(name, read_method, resource_type=None,
+                            replicas=None, **kwargs):
+    """Util method for polling status until it won't be all replicas running.
+
+    :param name: resource name
+    :param read_method: method to poll
+    :param resource_type: resource type for extended exceptions
+    :param replicas: expected replicas for extended exceptions
+    :param kwargs: additional kwargs for read_method
+    """
+    sleep_time = CONF.kubernetes.status_poll_interval
+    retries_total = CONF.kubernetes.status_total_retries
+
+    commonutils.interruptable_sleep(CONF.kubernetes.start_prepoll_delay)
+
+    i = 0
+    while i < retries_total:
+        resp = read_method(name=name, **kwargs)
+        resp_id = resp.metadata.uid
+        current_replicas = resp.status.replicas
+        ready_replicas = resp.status.ready_replicas
+        if (current_replicas is None or
+                ready_replicas is None or
+                current_replicas != ready_replicas):
+            i += 1
+            commonutils.interruptable_sleep(sleep_time)
+        else:
+            return
+        if i == retries_total:
+            raise exceptions.TimeoutException(
+                desired_status="%s replicas running" % ready_replicas,
+                resource_name=name,
+                resource_type=resource_type,
+                resource_id=resp_id or "<no id>",
+                resource_status="%s replicas running" % current_replicas,
+                timeout=(retries_total * sleep_time))
+
+
 def wait_for_not_found(name, read_method, resource_type=None, **kwargs):
     """Util method for polling status while resource exists.
 
@@ -81,7 +119,10 @@ def wait_for_not_found(name, read_method, resource_type=None, **kwargs):
         try:
             resp = read_method(name=name, **kwargs)
             resp_id = resp.metadata.uid
-            current_status = resp.status.phase
+            if hasattr(resp.status, "phase"):
+                current_status = resp.status.phase
+            else:
+                current_status = "Unknown"
         except rest.ApiException as ex:
             if ex.status == 404:
                 return
@@ -306,7 +347,7 @@ class Kubernetes(service.Service):
             "metadata": {
                 "name": name,
                 "labels": {
-                    "role": self._spec.get("env_id") or name
+                    "role": name
                 }
             },
             "spec": {
@@ -350,3 +391,129 @@ class Kubernetes(service.Service):
                 wait_for_not_found(name,
                                    read_method=self.get_pod,
                                    namespace=namespace)
+
+    @atomic.action_timer("kubernetes.get_replication_controller")
+    def get_rc(self, name, namespace):
+        return self.v1_client.read_namespaced_replication_controller(
+            name,
+            namespace=namespace
+        )
+
+    @atomic.action_timer("kubernetes.create_replication_controller")
+    def create_rc(self, name, replicas, image, namespace, command=None,
+                  status_wait=True):
+        """Create RC and wait until it won't be running.
+
+        :param name: replication controller name
+        :param replicas: number of replicas
+        :param image: image for each replica
+        :param namespace: replication controller namespace
+        :param command: array of strings representing container command
+        :param status_wait: wait replication controller for actual running
+               replicas
+        """
+        name = name or self.generate_random_name()
+        app = self.generate_random_name()
+
+        container_spec = {
+            "name": name,
+            "image": image
+        }
+        if command is not None and isinstance(command, (list, tuple)):
+            container_spec["command"] = list(command)
+
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+                "name": name,
+            },
+            "spec": {
+                "replicas": replicas,
+                "selector": {
+                    "app": app
+                },
+                "template": {
+                    "metadata": {
+                        "name": name,
+                        "labels": {
+                            "app": app
+                        }
+                    },
+                    "spec": {
+                        "serviceAccountName": namespace,
+                        "containers": [container_spec]
+                    }
+                }
+            }
+        }
+
+        if not self._spec.get("serviceaccounts"):
+            del manifest["spec"]["template"]["spec"]["serviceAccountName"]
+
+        self.v1_client.create_namespaced_replication_controller(
+            body=manifest,
+            namespace=namespace
+        )
+
+        if status_wait:
+            with atomic.ActionTimer(
+                    self,
+                    "kubernetes.wait_for_replication_controller_ready_replicas"
+            ):
+                wait_for_ready_replicas(
+                    name,
+                    read_method=self.get_rc,
+                    resource_type="Replication controller",
+                    replicas=replicas,
+                    namespace=namespace)
+        return name
+
+    @atomic.action_timer("kubernetes.scale_replication_controller")
+    def scale_rc(self, name, namespace, replicas, status_wait=True):
+        """Scale replication controller with number of replicas.
+
+        :param name: replication controller name
+        :param namespace: replication controller namespace
+        :param replicas: number of replicas replication controller scale to
+        :returns True if scale successful and False otherwise
+        """
+        self.v1_client.patch_namespaced_replication_controller(
+            name=name,
+            namespace=namespace,
+            body={"spec": {"replicas": replicas}}
+        )
+        if status_wait:
+            with atomic.ActionTimer(
+                    self,
+                    "kubernetes.wait_for_replication_controller_ready_replicas"
+            ):
+                wait_for_ready_replicas(
+                    name,
+                    read_method=self.get_rc,
+                    resource_type="Replication controller",
+                    replicas=replicas,
+                    namespace=namespace)
+
+    @atomic.action_timer("kubernetes.delete_replication_controller")
+    def delete_rc(self, name, namespace, status_wait=True):
+        """Delete replication controller and optionally wait for termination.
+
+        :param name: replication controller name
+        :param namespace: replication controller namespace
+        :param status_wait: wait replication controller for termination
+        """
+        self.v1_client.delete_namespaced_replication_controller(
+            name,
+            namespace=namespace,
+            body=k8s_config.V1DeleteOptions()
+        )
+        if status_wait:
+            with atomic.ActionTimer(
+                    self,
+                    "kubernetes.wait_for_replication_controller_termination"):
+                wait_for_not_found(
+                    name,
+                    read_method=self.get_rc,
+                    resource_type="Replication controller",
+                    namespace=namespace)

--- a/xrally_kubernetes/tasks/scenarios/replication_controllers.py
+++ b/xrally_kubernetes/tasks/scenarios/replication_controllers.py
@@ -1,0 +1,106 @@
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from rally.task import scenario
+
+from xrally_kubernetes.tasks import scenario as common_scenario
+
+
+@scenario.configure(name="Kubernetes.create_and_delete_replication_controller",
+                    platform="kubernetes")
+class RCCreateAndDelete(common_scenario.BaseKubernetesScenario):
+    """Kubernetes replication controller create and delete test.
+
+    Choose created namespace, create replication controller with defined image
+    and number of replicas, wait until it won't be running and delete it after.
+    """
+
+    def run(self, image, replicas, name=None, command=None, status_wait=True):
+        """Create and delete replication controller.
+
+        :param replicas: number of replicas for replication controller
+        :param image: replication controller image
+        :param name: replication controller custom name
+        :param command: array of strings representing container command
+        :param status_wait: wait replication controller status
+        """
+        namespace = self.choose_namespace()
+        name = self.client.create_rc(
+            name,
+            replicas=replicas,
+            image=image,
+            namespace=namespace,
+            command=command,
+            status_wait=status_wait
+        )
+
+        self.client.delete_rc(
+            name,
+            namespace=namespace,
+            status_wait=status_wait
+        )
+
+
+@scenario.configure(
+    name="Kubernetes.create_scale_and_delete_replication_controller",
+    platform="kubernetes"
+)
+class CreateScaleAndDeleteRCPlugin(common_scenario.BaseKubernetesScenario):
+    """Kubernetes replication controller scale test.
+
+    Create replication controller, scale it with number of replicas,
+    scale it with original number of replicas, delete replication controller.
+    """
+
+    def run(self, image, replicas, scale_replicas, name=None, command=None,
+            status_wait=True):
+        """Create RC, scale with replicas, revert scale and then delete it.
+
+        :param image: RC pod template image
+        :param replicas: original number of replicas
+        :param scale_replicas: number of replicas to scale
+        :param name: replication controller custom name
+        :param command: array of strings representing container command
+        :param status_wait: wait replication controller status
+        """
+        namespace = self.choose_namespace()
+
+        name = self.client.create_rc(
+            name,
+            namespace=namespace,
+            replicas=replicas,
+            image=image,
+            command=command,
+            status_wait=status_wait
+        )
+
+        self.client.scale_rc(
+            name,
+            namespace=namespace,
+            replicas=scale_replicas,
+            status_wait=status_wait
+        )
+
+        self.client.scale_rc(
+            name,
+            namespace=namespace,
+            replicas=replicas,
+            status_wait=status_wait
+        )
+
+        self.client.delete_rc(
+            name,
+            namespace=namespace,
+            status_wait=status_wait
+        )

--- a/xrally_tasks/all-in-one.yaml
+++ b/xrally_tasks/all-in-one.yaml
@@ -31,3 +31,32 @@ subtasks:
     namespaces:
       count: 3
       with_serviceaccount: true
+
+- title: Run a single workload with create/read/delete replication controller
+  scenario:
+    Kubernetes.create_and_delete_replication_controller:
+      image: kubernetes/pause
+      replicas: 2
+  runner:
+    constant:
+      concurrency: 2
+      times: 10
+  contexts:
+    namespaces:
+      count: 3
+      with_serviceaccount: true
+
+- title: Run a single workload with create/scale/delete replication controller
+  scenario:
+    Kubernetes.create_scale_and_delete_replication_controller:
+      image: kubernetes/pause
+      replicas: 2
+      scale_replicas: 3
+  runner:
+    constant:
+      concurrency: 2
+      times: 10
+  contexts:
+    namespaces:
+      count: 3
+      with_serviceaccount: true


### PR DESCRIPTION
Add rally scenario plugins and corresponding service methods
to create/read/delete replication controller and create/scale/delete
it.

Also, fix a few minor mistakes.