### PR TITLE
Fix omitted argument values for service module

### DIFF
--- a/xrally_kubernetes/service.py
+++ b/xrally_kubernetes/service.py
@@ -93,7 +93,7 @@ def wait_for_ready_replicas(name, read_method, resource_type=None,
             return
         if i == retries_total:
             raise exceptions.TimeoutException(
-                desired_status="%s replicas running" % ready_replicas,
+                desired_status="%s replicas running" % replicas,
                 resource_name=name,
                 resource_type=resource_type,
                 resource_id=resp_id or "<no id>",
@@ -255,6 +255,7 @@ class Kubernetes(service.Service):
             with atomic.ActionTimer(self,
                                     "kubernetes.wait_for_nc_become_active"):
                 wait_for_status(name,
+                                resource_type="Namespace",
                                 status="Active",
                                 read_method=self.get_namespace)
         return name
@@ -273,6 +274,7 @@ class Kubernetes(service.Service):
             with atomic.ActionTimer(self,
                                     "kubernetes.wait_namespace_termination"):
                 wait_for_not_found(name,
+                                   resource_type="Namespace",
                                    read_method=self.get_namespace)
 
     @atomic.action_timer("kubernetes.create_serviceaccount")
@@ -368,6 +370,7 @@ class Kubernetes(service.Service):
                 wait_for_status(name,
                                 status="Running",
                                 read_method=self.get_pod,
+                                resource_type="Pod",
                                 namespace=namespace)
         return name
 
@@ -390,6 +393,7 @@ class Kubernetes(service.Service):
                                     "kubernetes.wait_pod_termination"):
                 wait_for_not_found(name,
                                    read_method=self.get_pod,
+                                   resource_type="Pod",
                                    namespace=namespace)
 
     @atomic.action_timer("kubernetes.get_replication_controller")


### PR DESCRIPTION
Add resource_type values for all functions to display
message with the actual resource type instead of None.

Also change ready_replicas in wait_for_ready_replicas to
replicas argument value in case of ready_replicas could be
None.