### PR TITLE
Remove custom name as an scenario argument

### DIFF
--- a/tests/unit/tasks/scenarios/test_namespaces.py
+++ b/tests/unit/tasks/scenarios/test_namespaces.py
@@ -78,7 +78,7 @@ class CreateAndDeleteNamespaceTestCase(test.TestCase):
         scenario.client = client
         scenario.run()
 
-        client.create_namespace.assert_called_once_with(None, status_wait=True)
+        client.create_namespace.assert_called_once_with(status_wait=True)
         client.delete_namespace.assert_called_once_with("a", status_wait=True)
 
     def test_create_failed(self):
@@ -90,7 +90,7 @@ class CreateAndDeleteNamespaceTestCase(test.TestCase):
         scenario.generate_random_name = mock.MagicMock()
         scenario.client = client
         self.assertRaises(rest.ApiException, scenario.run)
-        client.create_namespace.assert_called_once_with(None, status_wait=True)
+        client.create_namespace.assert_called_once_with(status_wait=True)
         self.assertEqual(0, client.delete_namespace.call_count)
 
     def test_delete_failed(self):
@@ -103,5 +103,5 @@ class CreateAndDeleteNamespaceTestCase(test.TestCase):
         scenario.generate_random_name = mock.MagicMock()
         scenario.client = client
         self.assertRaises(rest.ApiException, scenario.run)
-        client.create_namespace.assert_called_once_with(None, status_wait=True)
+        client.create_namespace.assert_called_once_with(status_wait=True)
         client.delete_namespace.assert_called_once_with("a", status_wait=True)

--- a/tests/unit/tasks/scenarios/test_pods.py
+++ b/tests/unit/tasks/scenarios/test_pods.py
@@ -111,9 +111,8 @@ class CreateAndDeletePodTestCase(test.TestCase):
         self.scenario.run("test/image", command=["ls"])
 
         self.client.create_pod.assert_called_once_with(
-            None,
+            "test/image",
             namespace="ns",
-            image="test/image",
             command=["ls"],
             status_wait=True
         )
@@ -150,10 +149,9 @@ class CreateAndDeletePodTestCase(test.TestCase):
 
         self.assertRaises(rest.ApiException, self.scenario.run, "test/image")
         self.client.create_pod.assert_called_once_with(
-            None,
+            "test/image",
             command=None,
             namespace="ns",
-            image="test/image",
             status_wait=True
         )
         self.assertEqual(0, self.client.delete_pod.call_count)
@@ -169,10 +167,9 @@ class CreateAndDeletePodTestCase(test.TestCase):
 
         self.assertRaises(rest.ApiException, self.scenario.run, "test/image")
         self.client.create_pod.assert_called_once_with(
-            None,
+            "test/image",
             command=None,
             namespace="ns",
-            image="test/image",
             status_wait=True
         )
         self.client.get_pod.assert_called_once_with(

--- a/tests/unit/tasks/scenarios/test_replicasets.py
+++ b/tests/unit/tasks/scenarios/test_replicasets.py
@@ -41,7 +41,6 @@ class CreateAndDeleteReplicaSetTestCase(test.TestCase):
         self.scenario.run("test/image", 2, command=["ls"])
 
         self.client.create_replicaset.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -62,7 +61,6 @@ class CreateAndDeleteReplicaSetTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2)
         self.client.create_replicaset.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -80,7 +78,6 @@ class CreateAndDeleteReplicaSetTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2)
         self.client.create_replicaset.assert_called_once_with(
-            None,
             command=None,
             namespace="ns",
             replicas=2,
@@ -110,7 +107,6 @@ class CreateScaleAndDeleteReplicaSetTestCase(test.TestCase):
         self.scenario.run("test/image", 2, 3, command=["ls"])
 
         self.client.create_replicaset.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -132,7 +128,6 @@ class CreateScaleAndDeleteReplicaSetTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_replicaset.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -151,7 +146,6 @@ class CreateScaleAndDeleteReplicaSetTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_replicaset.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -175,7 +169,6 @@ class CreateScaleAndDeleteReplicaSetTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_replicaset.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -199,7 +192,6 @@ class CreateScaleAndDeleteReplicaSetTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_replicaset.assert_called_once_with(
-            None,
             command=None,
             namespace="ns",
             replicas=2,

--- a/tests/unit/tasks/scenarios/test_replication_controllers.py
+++ b/tests/unit/tasks/scenarios/test_replication_controllers.py
@@ -41,7 +41,6 @@ class CreateAndDeleteReplicationControllerTestCase(test.TestCase):
         self.scenario.run("test/image", 2, command=["ls"])
 
         self.client.create_rc.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -62,7 +61,6 @@ class CreateAndDeleteReplicationControllerTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2)
         self.client.create_rc.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -80,7 +78,6 @@ class CreateAndDeleteReplicationControllerTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2)
         self.client.create_rc.assert_called_once_with(
-            None,
             command=None,
             namespace="ns",
             replicas=2,
@@ -110,7 +107,6 @@ class CreateScaleAndDeleteReplicationControllerTestCase(test.TestCase):
         self.scenario.run("test/image", 2, 3, command=["ls"])
 
         self.client.create_rc.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -132,7 +128,6 @@ class CreateScaleAndDeleteReplicationControllerTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_rc.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -151,7 +146,6 @@ class CreateScaleAndDeleteReplicationControllerTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_rc.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -175,7 +169,6 @@ class CreateScaleAndDeleteReplicationControllerTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_rc.assert_called_once_with(
-            None,
             namespace="ns",
             image="test/image",
             replicas=2,
@@ -199,7 +192,6 @@ class CreateScaleAndDeleteReplicationControllerTestCase(test.TestCase):
         self.assertRaises(rest.ApiException, self.scenario.run,
                           "test/image", 2, 3)
         self.client.create_rc.assert_called_once_with(
-            None,
             command=None,
             namespace="ns",
             replicas=2,

--- a/tests/unit/tasks/scenarios/volumes/test_emptydir.py
+++ b/tests/unit/tasks/scenarios/volumes/test_emptydir.py
@@ -39,13 +39,14 @@ class CreateAndDeleteEmptyDirVolumeTestCase(test.TestCase):
 
     def test_create_and_delete_success(self):
         self.client.create_pod.return_value = "name"
-        self.scenario.run("test/image", command=["ls"], name="name",
+        self.scenario.run("test/image",
+                          command=["ls"],
                           mount_path="/opt/check")
 
         self.client.create_pod.assert_called_once_with(
-            "name",
+            "test/image",
+            name="name",
             namespace="ns",
-            image="test/image",
             command=["ls"],
             volume={
                 "mount_path": [
@@ -85,11 +86,11 @@ class CreateAndDeleteEmptyDirVolumeTestCase(test.TestCase):
         ]
 
         self.assertRaises(rest.ApiException, self.scenario.run, "test/image",
-                          name="name", mount_path="/opt/check")
+                          mount_path="/opt/check")
         self.client.create_pod.assert_called_once_with(
-            "name",
+            "test/image",
+            name="name",
             namespace="ns",
-            image="test/image",
             command=None,
             volume={
                 "mount_path": [
@@ -128,13 +129,13 @@ class CreateCheckAndDeleteEmptyDirVolumeTestCase(test.TestCase):
 
     def test_create_and_delete_success(self):
         self.client.create_pod.return_value = "name"
-        self.scenario.run("test/image", command=["ls"], name="name",
-                          check_cmd=["ls"], mount_path="/opt/check")
+        self.scenario.run("test/image", command=["ls"], check_cmd=["ls"],
+                          mount_path="/opt/check")
 
         self.client.create_pod.assert_called_once_with(
-            "name",
+            "test/image",
+            name="name",
             namespace="ns",
-            image="test/image",
             command=["ls"],
             volume={
                 "mount_path": [
@@ -180,12 +181,11 @@ class CreateCheckAndDeleteEmptyDirVolumeTestCase(test.TestCase):
         ]
 
         self.assertRaises(rest.ApiException, self.scenario.run, "test/image",
-                          name="name", mount_path="/opt/check",
-                          check_cmd=["ls"])
+                          mount_path="/opt/check", check_cmd=["ls"])
         self.client.create_pod.assert_called_once_with(
-            "name",
+            "test/image",
+            name="name",
             namespace="ns",
-            image="test/image",
             command=None,
             volume={
                 "mount_path": [

--- a/xrally_kubernetes/service.py
+++ b/xrally_kubernetes/service.py
@@ -235,13 +235,12 @@ class Kubernetes(service.Service):
         return self.v1_client.read_namespace(name)
 
     @atomic.action_timer("kubernetes.create_namespace")
-    def create_namespace(self, name, status_wait=True):
+    def create_namespace(self, status_wait=True):
         """Create namespace and wait until status phase won't be Active.
 
-        :param name: namespace name
         :param status_wait: wait namespace for Active status
         """
-        name = name or self.generate_random_name()
+        name = self.generate_random_name()
 
         manifest = {
             "apiVersion": "v1",
@@ -339,15 +338,15 @@ class Kubernetes(service.Service):
         return self.v1_client.read_namespaced_pod(name, namespace=namespace)
 
     @atomic.action_timer("kubernetes.create_pod")
-    def create_pod(self, name, image, namespace, command=None, volume=None,
-                   status_wait=True):
+    def create_pod(self, image, namespace, command=None, volume=None,
+                   name=None, status_wait=True):
         """Create pod and wait until status phase won't be Running.
 
-        :param name: pod's custom name
         :param image: pod's image
         :param namespace: chosen namespace to create pod into
         :param volume: a dict, which contains `mount_path` and `volume` keys
                with parts of pod's manifest as values
+        :param name: pod's custom name
         :param command: array of strings which represents container command
         :param status_wait: wait pod for Running status
         """
@@ -449,11 +448,10 @@ class Kubernetes(service.Service):
         )
 
     @atomic.action_timer("kubernetes.create_replication_controller")
-    def create_rc(self, name, replicas, image, namespace, command=None,
+    def create_rc(self, replicas, image, namespace, command=None,
                   status_wait=True):
         """Create RC and wait until it won't be running.
 
-        :param name: replication controller name
         :param replicas: number of replicas
         :param image: image for each replica
         :param namespace: replication controller namespace
@@ -461,7 +459,7 @@ class Kubernetes(service.Service):
         :param status_wait: wait replication controller for actual running
                replicas
         """
-        name = name or self.generate_random_name()
+        name = self.generate_random_name()
         app = self.generate_random_name()
 
         container_spec = {
@@ -575,11 +573,10 @@ class Kubernetes(service.Service):
         )
 
     @atomic.action_timer("kubernetes.create_replicaset")
-    def create_replicaset(self, name, namespace, replicas, image,
-                          command=None, status_wait=True):
+    def create_replicaset(self, namespace, replicas, image, command=None,
+                          status_wait=True):
         """Create replicaset and wait until it won't be ready.
 
-        :param name: replicaset name
         :param namespace: replicaset namespace
         :param replicas: number of replicaset replicas
         :param image: container's template image
@@ -587,7 +584,7 @@ class Kubernetes(service.Service):
         :param status_wait: wait for readiness if True
         """
         app = self.generate_random_name()
-        name = name or self.generate_random_name()
+        name = self.generate_random_name()
 
         container_spec = {
             "name": name,

--- a/xrally_kubernetes/tasks/contexts/namespaces.py
+++ b/xrally_kubernetes/tasks/contexts/namespaces.py
@@ -48,7 +48,7 @@ class NamespaceContext(common_context.BaseKubernetesContext):
 
         self.context["kubernetes"].setdefault("namespaces", [])
         for _ in range(self.config.get("count")):
-            name = self.client.create_namespace(None, status_wait=False)
+            name = self.client.create_namespace(status_wait=False)
             self.context["kubernetes"]["namespaces"].append(name)
             if self.config.get("with_serviceaccount"):
                 self.client.create_serviceaccount(name, namespace=name)

--- a/xrally_kubernetes/tasks/scenarios/namespaces.py
+++ b/xrally_kubernetes/tasks/scenarios/namespaces.py
@@ -49,11 +49,10 @@ class ListNamespaces(common_scenario.BaseKubernetesScenario):
                     platform="kubernetes")
 class CreateAndDeleteNamespace(common_scenario.BaseKubernetesScenario):
 
-    def run(self, name=None, status_wait=True):
+    def run(self, status_wait=True):
         """Create namespace, wait until it won't be active and then delete it.
 
-        :param name: namespace custom name
         :param status_wait: wait namespace status after creation
         """
-        name = self.client.create_namespace(name, status_wait=status_wait)
+        name = self.client.create_namespace(status_wait=status_wait)
         self.client.delete_namespace(name, status_wait=status_wait)

--- a/xrally_kubernetes/tasks/scenarios/pods.py
+++ b/xrally_kubernetes/tasks/scenarios/pods.py
@@ -82,11 +82,10 @@ class CreateAndDeletePod(common_scenario.BaseKubernetesScenario):
             data[state_map[e["name"]]] = [e["name"], duration]
         return data
 
-    def run(self, image, name=None, command=None, status_wait=True):
+    def run(self, image, command=None, status_wait=True):
         """Create pod, wait until it won't be running and then delete it.
 
         :param image: pod's image
-        :param name: pod's custom name
         :param command: array of strings, pod's command. Could be None if
                image have entrypoint
         :param status_wait: wait pod status after creation
@@ -94,9 +93,8 @@ class CreateAndDeletePod(common_scenario.BaseKubernetesScenario):
         namespace = self.choose_namespace()
 
         name = self.client.create_pod(
-            name,
+            image,
             namespace=namespace,
-            image=image,
             command=command,
             status_wait=status_wait
         )

--- a/xrally_kubernetes/tasks/scenarios/replicasets.py
+++ b/xrally_kubernetes/tasks/scenarios/replicasets.py
@@ -26,7 +26,7 @@ class CreateAndDeleteReplicaSet(common_scenario.BaseKubernetesScenario):
     of replicas, wait until it won't be running and delete it after.
     """
 
-    def run(self, image, replicas, name=None, command=None, status_wait=True):
+    def run(self, image, replicas, command=None, status_wait=True):
         """Create and delete replicaset and wait for status optionally.
 
         :param image: container's template image
@@ -38,7 +38,6 @@ class CreateAndDeleteReplicaSet(common_scenario.BaseKubernetesScenario):
         namespace = self.choose_namespace()
 
         name = self.client.create_replicaset(
-            name,
             replicas=replicas,
             image=image,
             namespace=namespace,
@@ -62,21 +61,19 @@ class CreateScaleAndDeleteReplicaSet(common_scenario.BaseKubernetesScenario):
     scale it with original number of replicas, delete replicaset.
     """
 
-    def run(self, image, replicas, scale_replicas, name=None, command=None,
+    def run(self, image, replicas, scale_replicas, command=None,
             status_wait=True):
         """Create replicaset, scale for number of replicas and then delete it.
 
         :param image: replicaset pod template image
         :param replicas: original number of replicas
         :param scale_replicas: number of replicas to scale
-        :param name: custom replicaset name
         :param command: array of strings representing container command
         :param status_wait: wait for full status if True
         """
         namespace = self.choose_namespace()
 
         name = self.client.create_replicaset(
-            name,
             namespace=namespace,
             replicas=replicas,
             image=image,

--- a/xrally_kubernetes/tasks/scenarios/replication_controllers.py
+++ b/xrally_kubernetes/tasks/scenarios/replication_controllers.py
@@ -26,18 +26,16 @@ class RCCreateAndDelete(common_scenario.BaseKubernetesScenario):
     and number of replicas, wait until it won't be running and delete it after.
     """
 
-    def run(self, image, replicas, name=None, command=None, status_wait=True):
+    def run(self, image, replicas, command=None, status_wait=True):
         """Create and delete replication controller.
 
         :param replicas: number of replicas for replication controller
         :param image: replication controller image
-        :param name: replication controller custom name
         :param command: array of strings representing container command
         :param status_wait: wait replication controller status
         """
         namespace = self.choose_namespace()
         name = self.client.create_rc(
-            name,
             replicas=replicas,
             image=image,
             namespace=namespace,
@@ -63,21 +61,19 @@ class CreateScaleAndDeleteRCPlugin(common_scenario.BaseKubernetesScenario):
     scale it with original number of replicas, delete replication controller.
     """
 
-    def run(self, image, replicas, scale_replicas, name=None, command=None,
+    def run(self, image, replicas, scale_replicas, command=None,
             status_wait=True):
         """Create RC, scale with replicas, revert scale and then delete it.
 
         :param image: RC pod template image
         :param replicas: original number of replicas
         :param scale_replicas: number of replicas to scale
-        :param name: replication controller custom name
         :param command: array of strings representing container command
         :param status_wait: wait replication controller status
         """
         namespace = self.choose_namespace()
 
         name = self.client.create_rc(
-            name,
             namespace=namespace,
             replicas=replicas,
             image=image,

--- a/xrally_kubernetes/tasks/scenarios/volumes/base.py
+++ b/xrally_kubernetes/tasks/scenarios/volumes/base.py
@@ -22,7 +22,7 @@ class PodWithVolumeBaseScenario(common_scenario.BaseKubernetesScenario):
         """Super class for all kubernetes pod with volume scenarios.
 
         :param image: pod's image
-        :param name: pod's custom name, equals to volume name
+        :param name: pod's name, equals to volume name
         :param check_cmd: pod exec command, available if volume_check is True
         :param command: pod container's command
         :param error_regexp: regexp string to search error in pod exec
@@ -35,8 +35,8 @@ class PodWithVolumeBaseScenario(common_scenario.BaseKubernetesScenario):
         namespace = self.choose_namespace()
 
         name = self.client.create_pod(
-            name,
-            image=image,
+            image,
+            name=name,
             volume=volume,
             namespace=namespace,
             command=command,

--- a/xrally_kubernetes/tasks/scenarios/volumes/emptydir.py
+++ b/xrally_kubernetes/tasks/scenarios/volumes/emptydir.py
@@ -24,7 +24,7 @@ from xrally_kubernetes.tasks.scenarios.volumes import base
 class CreateAndDeletePodWithEmptyDirVolume(base.PodWithVolumeBaseScenario):
 
     def run(self, image, mount_path, check_cmd=None, error_regexp=None,
-            name=None, command=None, status_wait=True):
+            command=None, status_wait=True):
         """Create pod with emptyDir volume, optionally check and delete then.
 
         Create pod with emptyDir volume, optionally wait for it's readiness,
@@ -38,7 +38,7 @@ class CreateAndDeletePodWithEmptyDirVolume(base.PodWithVolumeBaseScenario):
         :param command: array of strings representing container command
         :param status_wait: wait pod status for success if True
         """
-        name = name or self.generate_random_name()
+        name = self.generate_random_name()
 
         volume = {
             "mount_path": [


### PR DESCRIPTION
Remove custom name as an scenario argument - let's
use generated random names for stronger division of
resources created by rally and other.