### PR TITLE
Add args to namespaces context to specify custom ns

### DIFF
--- a/samples/scenario/contexts/namespaces.json
+++ b/samples/scenario/contexts/namespaces.json
@@ -19,6 +19,27 @@
           "with_serviceaccount": true
         }
       }
+    },
+    {
+      "title": "Run a single workload with create/read/delete pod",
+      "scenario": {
+        "Kubernetes.create_and_delete_pod": {
+          "image": "kubernetes/pause"
+        }
+      },
+      "runner": {
+        "constant": {
+          "concurrency": 2,
+          "times": 10
+        }
+      },
+      "contexts": {
+        "namespaces": {
+          "namespaces": [
+            "default"
+          ]
+        }
+      }
     }
   ]
 }

--- a/samples/scenario/contexts/namespaces.yaml
+++ b/samples/scenario/contexts/namespaces.yaml
@@ -13,3 +13,15 @@ subtasks:
     namespaces:
       count: 4
       with_serviceaccount: true
+- title: Run a single workload with create/read/delete pod
+  scenario:
+    Kubernetes.create_and_delete_pod:
+      image: kubernetes/pause
+  runner:
+    constant:
+      concurrency: 2
+      times: 10
+  contexts:
+    namespaces:
+      namespaces:
+      - default

--- a/tests/unit/tasks/contexts/test_namespaces.py
+++ b/tests/unit/tasks/contexts/test_namespaces.py
@@ -132,3 +132,20 @@ class NamespacesContextTestCase(test.TestCase):
         self.assertEqual(3, self.client.create_namespace.call_count)
         self.assertEqual(3, self.client.create_serviceaccount.call_count)
         self.assertEqual(3, self.client.create_secret.call_count)
+
+    def test_namespaces_context_specify_namespaces(self):
+        old_config = copy.deepcopy(self.ctx.config)
+        old_config.update({
+            "namespaces": ["default", "non-default"],
+            "namespace_choice_method": "round_robin"
+        })
+        self.ctx.config = old_config
+        self.ctx.setup()
+
+        self.assertEqual(["default", "non-default"],
+                         self.ctx.context["kubernetes"]["namespaces"])
+        self.assertEqual(
+            "round_robin",
+            self.ctx.context["kubernetes"]["namespace_choice_method"]
+        )
+        self.assertFalse(self.ctx.context["kubernetes"]["serviceaccounts"])


### PR DESCRIPTION
Allow user to specify already existed namespaces instead
of creating new ones.