### PR TITLE
Create client key and certificate files

### DIFF
--- a/tests/unit/env/platforms/test_existing.py
+++ b/tests/unit/env/platforms/test_existing.py
@@ -92,22 +92,24 @@ class KubernetesPlatformTestCase(test.TestCase):
 
 class KubernetesPlatformFromSysEnvTestCase(test.TestCase):
 
-    def test_cert_vars(self):
+    @mock.patch.object(existing.KubernetesPlatform, '_create_cert_files')
+    def test_cert_vars(self, mock_create):
+        mock_create.return_value = {
+            "cert_auth": "new-stub.crt",
+            "ccert": "new-client-stub.crt",
+            "ckey": "new-client-stub.key"
+        }
         sys_env = {
             "KUBERNETES_CERT_AUTH": "stub.crt",
             "KUBERNETES_HOST": "localhost:8443",
             "KUBERNETES_CLIENT_KEY": "client-stub.key",
             "KUBERNETES_CLIENT_CERT": "client-stub.crt"
         }
-
-        def expand_path(x):
-            return os.path.abspath(os.path.expanduser(x))
-
         expected = {
             "server": "localhost:8443",
-            "certificate-authority": expand_path("stub.crt"),
-            "client-certificate": expand_path("client-stub.crt"),
-            "client-key": expand_path("client-stub.key"),
+            "certificate-authority": "new-stub.crt",
+            "client-certificate": "new-client-stub.crt",
+            "client-key": "new-client-stub.key",
             "tls_insecure": False
         }
 
@@ -150,7 +152,13 @@ class KubernetesPlatformFromSysEnvTestCase(test.TestCase):
         self.assertTrue(res["available"])
         self.assertEqual(expected, res["spec"])
 
-    def test_all_vars(self):
+    @mock.patch.object(existing.KubernetesPlatform, '_create_cert_files')
+    def test_all_vars(self, mock_create):
+        mock_create.return_value = {
+            "cert_auth": "new-stub.crt",
+            "ccert": "new-client-stub.crt",
+            "ckey": "new-client-stub.key"
+        }
         sys_env = {
             "KUBERNETES_CERT_AUTH": "stub.crt",
             "KUBERNETES_HOST": "localhost:8443",
@@ -160,15 +168,11 @@ class KubernetesPlatformFromSysEnvTestCase(test.TestCase):
             "KUBERNETES_CLIENT_CERT": "client-stub.crt",
             "KUBERNETES_TLS_INSECURE": True
         }
-
-        def expand_path(x):
-            return os.path.abspath(os.path.expanduser(x))
-
         expected = {
             "server": "localhost:8443",
-            "certificate-authority": expand_path("stub.crt"),
-            "client-certificate": expand_path("client-stub.crt"),
-            "client-key": expand_path("client-stub.key"),
+            "certificate-authority": "new-stub.crt",
+            "client-certificate": "new-client-stub.crt",
+            "client-key": "new-client-stub.key",
             "tls_insecure": True
         }
 

--- a/xrally_kubernetes/common/opts.py
+++ b/xrally_kubernetes/common/opts.py
@@ -24,7 +24,10 @@ KUBERNETES_OPTS = [
                help="Kubernetes total retries to read resource status"),
     cfg.FloatOpt("status_poll_interval",
                  default=1.0,
-                 help="Kubernetes status poll interval")
+                 help="Kubernetes status poll interval"),
+    cfg.StrOpt("cert_dir",
+               default="~/.rally/cert",
+               help="Directory for storing certification files")
 ]
 
 

--- a/xrally_kubernetes/env/platforms/existing.py
+++ b/xrally_kubernetes/env/platforms/existing.py
@@ -17,9 +17,12 @@ import shutil
 import traceback
 import uuid
 
+from rally.common import cfg
 from rally.env import platform
 
 from xrally_kubernetes import service as k8s_service
+
+CONF = cfg.CONF
 
 
 @platform.configure(name="existing", platform="kubernetes")
@@ -153,7 +156,7 @@ class KubernetesPlatform(platform.Platform):
         :param ccert: client certificate file
         :param ckey: client key file
         """
-        certs = os.path.abspath(os.path.expanduser("~/.rally/certs"))
+        certs = os.path.abspath(os.path.expanduser(CONF.kubernetes.cert_dir))
         if not os.path.exists(certs):
             os.makedirs(certs)
 


### PR DESCRIPTION
Copy certification files provided by kubeclient object and save them
as new files. This fixes [1].

[1] https://bugs.launchpad.net/rally/+bug/1798375