### PR TITLE
Allow offline testing in PodWithClusterIPSvc

### DIFF
--- a/tests/unit/tasks/scenarios/test_services.py
+++ b/tests/unit/tasks/scenarios/test_services.py
@@ -81,7 +81,7 @@ class PodWithClusterIPSvcTestCase(test.TestCase):
         self.client.create_job.assert_called_once_with(
             name="test",
             namespace="ns",
-            image="appropriate/curl",
+            image="appropriate/curl:edge",
             command=["curl", "10.0.0.5:3030"],
             status_wait=True
         )
@@ -145,7 +145,7 @@ class PodWithClusterIPSvcTestCase(test.TestCase):
         self.client.create_job.assert_called_once_with(
             name="test",
             namespace="ns",
-            image="appropriate/curl",
+            image="appropriate/curl:edge",
             command=["curl", "192.168.0.3:80"],
             status_wait=True
         )

--- a/xrally_kubernetes/tasks/scenarios/services.py
+++ b/xrally_kubernetes/tasks/scenarios/services.py
@@ -93,7 +93,7 @@ class PodWithClusterIPSvc(common_scenario.BaseKubernetesScenario):
         self.client.create_job(
             name=name,
             namespace=namespace,
-            image="appropriate/curl",
+            image="appropriate/curl:edge",
             command=command,
             status_wait=True
         )


### PR DESCRIPTION
It sets edge as image tag for appropriate/curl not to force a download.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>