### PR TITLE
Enforce baseline Pod Security Standard with namespace labels

### DIFF
--- a/xrally_kubernetes/service.py
+++ b/xrally_kubernetes/service.py
@@ -238,7 +238,8 @@ class Kubernetes(service.Service):
             "metadata": {
                 "name": name,
                 "labels": {
-                    "role": name
+                    "role": name,
+                    "pod-security.kubernetes.io/enforce": "baseline"
                 }
             }
         }


### PR DESCRIPTION
It allows running the xrally_kubernetes testcases vs clusters where PodSecurityConfiguration enforces "restricted" [1].
Please note that Kubernetes.create_and_delete_pod_with_hostpath_volume even requests for privileged [2].

[1] https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/
[2] https://kubernetes.io/docs/concepts/storage/volumes/#hostpath